### PR TITLE
起動後のログイン処理をLoginScene起点に変更

### DIFF
--- a/Assets/Scripts/Auth/Login.cs
+++ b/Assets/Scripts/Auth/Login.cs
@@ -33,7 +33,8 @@ public class Login : MonoBehaviour
             //PlayerPrefs.DeleteAll();
             // Debug.Log(LoadAccessToken());
             // LoadMainScene();
-            LoadMyCharactersScene();
+            // LoadMyCharactersScene();
+            LoadTitleScene();
         }
     }
 
@@ -52,14 +53,13 @@ public class Login : MonoBehaviour
         var isSuccess = (bool) coroutine.Current;
         if (isSuccess)
         {
-            SceneManager.LoadScene("MyCharactersScene");
         }
         else
         {
             Debug.Log("Login is failed");
         }
     }
-
+    
 
     void LoadMainScene()
     {
@@ -71,6 +71,11 @@ public class Login : MonoBehaviour
         SceneManager.LoadScene("MyCharactersScene");
     }
 
+    void LoadTitleScene()
+    {
+            SceneManager.LoadScene("TitleScene");
+    }
+    
     // Update is called once per frame
     void Update()
     {

--- a/Assets/Scripts/Auth/Login.cs
+++ b/Assets/Scripts/Auth/Login.cs
@@ -19,22 +19,22 @@ public class Login : MonoBehaviour
     // Start is called before the first frame update
     void Start()
     {
-        
-        
+        StartCoroutine(CheckLoginSuccess());
+    }
+
+    IEnumerator CheckLoginSuccess()
+    {
     var loginService = new LoginService();
-        if (loginService.LoadAccessToken() ==
-            "")
+    var coroutine = loginService.LogihWithCredential();
+    yield return StartCoroutine(coroutine);
+    var isSuccess = (bool) coroutine.Current;
+        if (isSuccess)
         {
-            Debug.Log("not logged in");
-            // DoLogin();
+            LoadTitleScene();
         }
         else
         {
-            //PlayerPrefs.DeleteAll();
-            // Debug.Log(LoadAccessToken());
-            // LoadMainScene();
-            // LoadMyCharactersScene();
-            LoadTitleScene();
+            Debug.Log("not logged in");
         }
     }
 


### PR DESCRIPTION
## why
- Close #19 


## what
- LoginSceneからゲームが始まるようにする
  - トークンによるログインが成功したらタイトル画面に自動的に遷移
  - 失敗したら、そのまま何も起こらない
    - そのままログインし直すことができる