### PR TITLE
タイトルでログインに失敗した場合のシーン遷移

### DIFF
--- a/Assets/Scripts/TitlePage/TitlePageController.cs
+++ b/Assets/Scripts/TitlePage/TitlePageController.cs
@@ -31,5 +31,9 @@ public class TitlePageController : MonoBehaviour
             {
                 SceneManager.LoadScene("MenuScene");
             }
+            else
+            {
+                SceneManager.LoadScene("LoginScene");
+            }
     }
 }


### PR DESCRIPTION
## why
- タイトルでタップしたときにログインに失敗した場合、そこから先に進めなくなる

## what
タイトルでタップしたときにログインに失敗した場合、ログインシーンに飛ぶようにした