### PR TITLE
メッセージエリアをクリックでメッセージを進める

### DIFF
--- a/.idea/.idea.HokumaFriends/.idea/contentModel.xml
+++ b/.idea/.idea.HokumaFriends/.idea/contentModel.xml
@@ -30,6 +30,9 @@
             <e p="QuestListController.cs" t="Include" />
           </e>
           <e p="Story" t="Include">
+            <e p="MessageArea.cs" t="Include" />
+            <e p="MessageAreaClickHandler.cs" t="Include" />
+            <e p="MessageProceedManager.cs" t="Include" />
             <e p="StoryController.cs" t="Include" />
             <e p="StoryListController.cs" t="Include" />
           </e>

--- a/Assets/Scenes/StoryScene.unity
+++ b/Assets/Scenes/StoryScene.unity
@@ -172,7 +172,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
-  m_RaycastTarget: 1
+  m_RaycastTarget: 0
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
@@ -731,6 +731,8 @@ GameObject:
   - component: {fileID: 1581986358}
   - component: {fileID: 1581986360}
   - component: {fileID: 1581986359}
+  - component: {fileID: 1581986362}
+  - component: {fileID: 1581986361}
   m_Layer: 0
   m_Name: TextAreaBackground
   m_TagString: Untagged
@@ -796,3 +798,41 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1581986357}
   m_CullTransparentMesh: 0
+--- !u!114 &1581986361
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1581986357}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 666b970c16444cec96fac44cd187b509, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1581986362
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1581986357}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5714b668bb8c4d66b85029a4251c9667, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  onClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1581986361}
+        m_MethodName: OnClickHander
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2

--- a/Assets/Scripts/Story/MessageArea.cs
+++ b/Assets/Scripts/Story/MessageArea.cs
@@ -1,0 +1,13 @@
+using UnityEngine;
+
+namespace Story
+{
+
+    public class MessageArea : MonoBehaviour
+    {
+         public void OnClickHander()
+         {
+             Debug.Log("clicked");
+         }
+    }
+}

--- a/Assets/Scripts/Story/MessageArea.cs
+++ b/Assets/Scripts/Story/MessageArea.cs
@@ -8,6 +8,7 @@ namespace Story
          public void OnClickHander()
          {
              Debug.Log("clicked");
+             MessageProceedManager.Instance.SetupNextMessage();
          }
     }
 }

--- a/Assets/Scripts/Story/MessageArea.cs.meta
+++ b/Assets/Scripts/Story/MessageArea.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 666b970c16444cec96fac44cd187b509
+timeCreated: 1605732628

--- a/Assets/Scripts/Story/MessageAreaClickHandler.cs
+++ b/Assets/Scripts/Story/MessageAreaClickHandler.cs
@@ -1,0 +1,21 @@
+using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.Events;
+
+namespace Story
+{
+    public class MessageAreaClickHandler : MonoBehaviour, IPointerClickHandler
+    {
+     public UnityEvent onClick;
+     
+         public void OnPointerClick(PointerEventData pointerEventData)
+         {
+             //Output to console the clicked GameObject's name and the following message. You can replace this with your own actions for when clicking the GameObject.
+             Debug.Log(name + " Game Object Clicked!", this);
+     
+             // invoke your event
+             onClick.Invoke();
+         }
+
+    }
+}

--- a/Assets/Scripts/Story/MessageAreaClickHandler.cs.meta
+++ b/Assets/Scripts/Story/MessageAreaClickHandler.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 5714b668bb8c4d66b85029a4251c9667
+timeCreated: 1605733236

--- a/Assets/Scripts/Story/MessageProceedManager.cs
+++ b/Assets/Scripts/Story/MessageProceedManager.cs
@@ -1,0 +1,50 @@
+namespace Story
+{
+    class MessageProceedManager
+    {
+        private MessageProceedManager()
+        {
+        }
+
+        public static readonly MessageProceedManager Instance = new MessageProceedManager();
+
+        private string oneMessage;
+        private string[] messages;
+        private int messageCharIndex = 0;
+        int messagesIndex = 0;
+
+        public void SetupMessages()
+        {
+            messages = new[] {"こんにちはクマ！", "さようならクマ！"};
+            oneMessage = messages[0];
+        }
+
+        public string GetCurrentPartialMessage()
+        {
+            if (messageCharIndex < oneMessage.Length)
+            {
+                messageCharIndex++;
+            }
+            else if (messageCharIndex == oneMessage.Length)
+            {
+                if (messagesIndex < messages.Length - 1)
+                {
+                    // SetupNextMessage();
+                    return null;
+                }
+            }
+
+            return oneMessage.Substring(0,messageCharIndex);
+        }
+
+        public void SetupNextMessage()
+        {
+            if (messagesIndex < messages.Length-1)
+            {
+                messagesIndex++;
+                oneMessage = messages[messagesIndex];
+                messageCharIndex = 0;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Story/MessageProceedManager.cs.meta
+++ b/Assets/Scripts/Story/MessageProceedManager.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 77ce286fa19d4182a7ca17a04be1d1eb
+timeCreated: 1605734491

--- a/Assets/Scripts/Story/StoryController.cs
+++ b/Assets/Scripts/Story/StoryController.cs
@@ -11,12 +11,9 @@ namespace Story
         [SerializeField] private Text messageArea;
         [SerializeField] private Text characterName;
 
-        private string oneMessage;
-        private string[] messages;
 
-        private int messageCharIndex = 0;
-        int messagesIndex = 0;
         private double dt = 0.0f;
+        private MessageProceedManager _messageProceedManager = MessageProceedManager.Instance;
 
         // Start is called before the first frame update
         void Start()
@@ -31,17 +28,10 @@ namespace Story
             dt += Time.deltaTime;
             if (dt > 0.1f)
             {
-                if (messageCharIndex < oneMessage.Length)
+                var message = _messageProceedManager.GetCurrentPartialMessage();
+                if (message != null)
                 {
-                    messageArea.text += oneMessage[messageCharIndex];
-                    messageCharIndex++;
-                }
-                else if (messageCharIndex == oneMessage.Length)
-                {
-                    if (messagesIndex < messages.Length - 1)
-                    {
-                        // SetupNextMessage();
-                    }
+                    messageArea.text = message;
                 }
 
                 dt = 0.0f;
@@ -51,15 +41,11 @@ namespace Story
         void SetupMessages()
         {
             messageArea.text = "";
-            messages = new[] {"こんにちはクマ！", "さようならクマ！"};
-            oneMessage = messages[0];
+            _messageProceedManager.SetupMessages();
         }
 
         public void SetupNextMessage()
         {
-            messagesIndex++;
-            oneMessage = messages[messagesIndex];
-            messageCharIndex = 0;
             messageArea.text = "";
         }
     }

--- a/Assets/Scripts/Story/StoryController.cs
+++ b/Assets/Scripts/Story/StoryController.cs
@@ -40,7 +40,7 @@ namespace Story
                 {
                     if (messagesIndex < messages.Length - 1)
                     {
-                        SetupNextMessage();
+                        // SetupNextMessage();
                     }
                 }
 
@@ -55,7 +55,7 @@ namespace Story
             oneMessage = messages[0];
         }
 
-        void SetupNextMessage()
+        public void SetupNextMessage()
         {
             messagesIndex++;
             oneMessage = messages[messagesIndex];


### PR DESCRIPTION
## why
- テキストを自由なタイミングで進められない

## what
- 自動で次のメッセージへ進めないようにし、メッセージエリアをクリックでメッセージを進めるように変更
- MessageProceedManagerとしてモデルを抽出
  - とりあえずはシングルトンで管理

## 参考
https://stackoverflow.com/questions/55141565/onclickevent-on-a-textobject-unity/55141856