### PR TITLE
APIのホスト名を開発用と本番用で使い分けられるようにする

### DIFF
--- a/.idea/.idea.HokumaFriends/.idea/contentModel.xml
+++ b/.idea/.idea.HokumaFriends/.idea/contentModel.xml
@@ -5,6 +5,9 @@
       <e p="Assembly-CSharp.csproj" t="IncludeRecursive" />
       <e p="Assets" t="Include">
         <e p="Scripts" t="Include">
+          <e p="api" t="Include">
+            <e p="ApiHostName.cs" t="Include" />
+          </e>
           <e p="Auth" t="Include">
             <e p="Login.cs" t="Include" />
             <e p="LoginService.cs" t="Include" />

--- a/Assets/Scripts/Auth/LoginService.cs
+++ b/Assets/Scripts/Auth/LoginService.cs
@@ -1,5 +1,6 @@
 using UnityEngine.Networking;
 using System.Collections;
+using api;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 
@@ -30,7 +31,7 @@ namespace GachaController.Auth
             }
             else
             {
-                var url = "http://localhost:8000/api/auth/login";
+                var url = ApiHostName.instance.hostName + "/api/auth/login";
                 WWWForm form = new WWWForm();
                 form.AddField("email", email);
                 form.AddField("password", password);
@@ -62,7 +63,7 @@ namespace GachaController.Auth
         public IEnumerator LogihWithCredential()
         {
             var accessToken = LoadAccessToken();
-            var request = UnityWebRequest.Get("http://localhost:8000/api/auth/me");
+            var request = UnityWebRequest.Get(ApiHostName.instance.hostName + "/api/auth/me");
             request.SetRequestHeader("Authorization", "Bearer " + accessToken);
             request.SetRequestHeader("Content-Type", "application/json");
             yield return request.SendWebRequest();

--- a/Assets/Scripts/Auth/SignupController.cs
+++ b/Assets/Scripts/Auth/SignupController.cs
@@ -1,4 +1,5 @@
 using System.Collections;
+using api;
 using UnityEngine;
 using UnityEngine.Networking;
 using UnityEngine.SceneManagement;
@@ -49,7 +50,7 @@ namespace GachaController.Auth
                 form.AddField("email", email);
                 form.AddField("name", username);
                 form.AddField("password", password);
-                var url = "http://localhost:8000/api/register";
+                var url = ApiHostName.instance.hostName + "/api/register";
                 var response = UnityWebRequest.Post(url, form);
                 yield return response.Send();
                 var accessToken = JsonUtility.FromJson<Token>(response.downloadHandler.text);

--- a/Assets/Scripts/Gacha/GachaController.cs
+++ b/Assets/Scripts/Gacha/GachaController.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
+using api;
 using GachaController.Auth;
 using UnityEngine;
 using UnityEngine.Networking;
@@ -40,7 +41,7 @@ namespace GachaController
             //URLをGETで用意
             var webRequest =
                 UnityWebRequest.Get(
-                    "http://localhost:8000/api/gacha/platinum/");
+                    ApiHostName.instance.hostName + "/api/gacha/platinum/");
             //URLに接続して結果が戻ってくるまで待機
             webRequest.SetRequestHeader("Authorization", "Bearer "+(new LoginService()).LoadAccessToken());
             yield return webRequest.SendWebRequest();

--- a/Assets/Scripts/MyCharacters/MyCharacters.cs
+++ b/Assets/Scripts/MyCharacters/MyCharacters.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using api;
 using UnityEngine;
 using UnityEngine.UI;
 using UnityEngine.Networking;
@@ -42,7 +43,7 @@ public class MyCharacters : MonoBehaviour
 
     IEnumerator FetchMyCharacters()
     {
-        var request = UnityWebRequest.Get("http://localhost:8000/api/myCharacters");
+        var request = UnityWebRequest.Get(ApiHostName.instance.hostName + "/api/myCharacters");
         const string accessTokenKey = "accessTokenKey";
         Debug.Log(PlayerPrefs.GetString(accessTokenKey));
         request.SetRequestHeader("Authorization", "Bearer " + PlayerPrefs.GetString(accessTokenKey));

--- a/Assets/Scripts/Quest/QuestApi.cs
+++ b/Assets/Scripts/Quest/QuestApi.cs
@@ -1,4 +1,5 @@
 using System;
+using api;
 using UnityEngine;
 using Cysharp.Threading.Tasks;
 using GachaController.Auth;
@@ -27,7 +28,7 @@ namespace Quest
             var json = JsonUtility.ToJson(data);
             byte[] byteData = System.Text.Encoding.UTF8.GetBytes(json);
             
-            var url = "http://localhost:8000/api/questResult/updateQuestClearResult";
+            var url = ApiHostName.instance.hostName + "/api/questResult/updateQuestClearResult";
             UnityWebRequest request = new UnityWebRequest(url, "POST");
             request.uploadHandler = (UploadHandler) new UploadHandlerRaw(byteData);
             request.downloadHandler = (DownloadHandler) new DownloadHandlerBuffer();

--- a/Assets/Scripts/api.meta
+++ b/Assets/Scripts/api.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 083a05aa16a7475d8ea035b44c86704a
+timeCreated: 1606033626

--- a/Assets/Scripts/api/ApiHostName.cs
+++ b/Assets/Scripts/api/ApiHostName.cs
@@ -1,0 +1,17 @@
+using System;
+using UnityEngine;
+
+namespace api
+{
+    public class ApiHostName
+    {
+        private ApiHostName()
+        {
+            hostName = Environment.GetEnvironmentVariable("HOKUMA_FRIENDS_HOSTNAME") ?? "http://localhost:8000";
+            Debug.Log(hostName);
+        }
+
+        public static ApiHostName instance = new ApiHostName();
+        public string hostName;
+    }
+}

--- a/Assets/Scripts/api/ApiHostName.cs
+++ b/Assets/Scripts/api/ApiHostName.cs
@@ -7,8 +7,8 @@ namespace api
     {
         private ApiHostName()
         {
-            hostName = Environment.GetEnvironmentVariable("HOKUMA_FRIENDS_HOSTNAME") ?? "http://localhost:8000";
-            Debug.Log(hostName);
+            // hostName = Environment.GetEnvironmentVariable("HOKUMA_FRIENDS_HOSTNAME", EnvironmentVariableTarget.User) ?? "http://localhost:8000";
+            hostName = "https://kotokotosoft.com";
         }
 
         public static ApiHostName instance = new ApiHostName();

--- a/Assets/Scripts/api/ApiHostName.cs.meta
+++ b/Assets/Scripts/api/ApiHostName.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 358284f02cc0d476e988d4aa78ede1d3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## why
- 本番用と開発用でAPIを使い分けたい
- ちょうど本番用のAPIバックエンドができた

## what
- 環境変数を使ってAPIのホスト名を設定できるように・・できなかった
  - 以下参照
  - とりあえず、コードに直接書き込むことに（デフォルトではkotokotosoft.com）
- これでAPIのホスト名を開発用と本番用で使い分けられる


環境変数の値を取得するには？［C#／VB］
https://www.atmarkit.co.jp/ait/articles/1803/07/news023.html 

どうやら
Environment.GetEnvironmentVariables(EnvironmentVariableTarget.User)
だと一つも環境変数が読み込めないらしい
18:10

> MacOS および Linux 上の .NET Core では、コンピューターごとまたはユーザーごとの環境変数はサポートされていません。

https://docs.microsoft.com/ja-jp/dotnet/api/system.environment.getenvironmentvariable?view=net-5.0