### PR TITLE
マスタデータからのストーリーデータ取得

### DIFF
--- a/.idea/.idea.HokumaFriends/.idea/contentModel.xml
+++ b/.idea/.idea.HokumaFriends/.idea/contentModel.xml
@@ -18,6 +18,10 @@
             <e p="SignupController.cs" t="Include" />
           </e>
           <e p="BackgroundImage.cs" t="Include" />
+          <e p="DataVersion" t="Include">
+            <e p="LocalDataVersionRepository.cs" t="Include" />
+            <e p="MasterDataVersionApi.cs" t="Include" />
+          </e>
           <e p="Dialog" t="Include">
             <e p="LoginErrorDialog.cs" t="Include" />
             <e p="OkCancelDialog.cs" t="Include" />
@@ -47,6 +51,7 @@
             <e p="MessageProceedManager.cs" t="Include" />
             <e p="sentence.cs" t="Include" />
             <e p="Story.cs" t="Include" />
+            <e p="StoryApi.cs" t="Include" />
             <e p="StoryController.cs" t="Include" />
             <e p="StoryListButton.cs" t="Include" />
             <e p="StoryListController.cs" t="Include" />

--- a/Assets/Scripts/DataVersion.meta
+++ b/Assets/Scripts/DataVersion.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: f7db68fe4c57416c9e3763e59f134473
+timeCreated: 1607682765

--- a/Assets/Scripts/DataVersion/LocalDataVersionRepository.cs
+++ b/Assets/Scripts/DataVersion/LocalDataVersionRepository.cs
@@ -1,0 +1,18 @@
+using UnityEngine;
+
+namespace MasterDataVersion
+{
+    public class LocalDataVersionRepository
+    {
+        private readonly string localDataVersionKey = "localDataVersionKey";
+        public int GetLocalDataVersion()
+        {
+            return PlayerPrefs.GetInt(localDataVersionKey);
+        }
+
+        public void UpdateLocalDataVersion(int version)
+        {
+            PlayerPrefs.SetInt(localDataVersionKey, version);
+        }
+    }
+}

--- a/Assets/Scripts/DataVersion/LocalDataVersionRepository.cs.meta
+++ b/Assets/Scripts/DataVersion/LocalDataVersionRepository.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 3174b55ce68648529fc39aa10a822129
+timeCreated: 1607682922

--- a/Assets/Scripts/DataVersion/MasterDataVersionApi.cs
+++ b/Assets/Scripts/DataVersion/MasterDataVersionApi.cs
@@ -1,0 +1,12 @@
+using Cysharp.Threading.Tasks;
+
+namespace DataVersion
+{
+    public class MasterDataVersionApi
+    {
+        public async UniTask<int> GetMasterDataVersion()
+        {
+            return 2;
+        }
+    }
+}

--- a/Assets/Scripts/DataVersion/MasterDataVersionApi.cs.meta
+++ b/Assets/Scripts/DataVersion/MasterDataVersionApi.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 7198f0e110364c8eae524ea8ba6e2233
+timeCreated: 1607682779

--- a/Assets/Scripts/Story/Story.cs
+++ b/Assets/Scripts/Story/Story.cs
@@ -8,6 +8,8 @@ namespace Story
         public int id;
         public string title;
         public Sentences sentences;
+        public string created_at;
+        public string updated_at;
 
         public Story(int id, string title, Sentences sentences)
         {

--- a/Assets/Scripts/Story/StoryApi.cs
+++ b/Assets/Scripts/Story/StoryApi.cs
@@ -1,0 +1,28 @@
+using System;
+using api;
+using Cysharp.Threading.Tasks;
+using UnityEngine;
+using UnityEngine.Networking;
+
+namespace Story
+{
+    [Serializable]
+    class Stories
+    {
+        public Story2[] stories;
+    }
+
+    public class StoryApi
+    {
+        public async UniTask<Story2[]> GetAll()
+        {
+            // var request = UnityWebRequest.Get(ApiHostName.instance.hostName + "/api/stories");
+            var request = UnityWebRequest.Get("http://localhost:8001" + "/api/stories");
+            await request.SendWebRequest();
+            var stories = JsonUtility.FromJson<Stories>(request.downloadHandler.text);
+            Debug.Log(request.downloadHandler.text);
+            Debug.Log(stories);
+            return stories.stories;
+        }
+    }
+}

--- a/Assets/Scripts/Story/StoryApi.cs.meta
+++ b/Assets/Scripts/Story/StoryApi.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 94c10344f15b4f3a8e4927f6a6ececda
+timeCreated: 1607650465

--- a/Assets/Scripts/Story/StoryRepository.cs
+++ b/Assets/Scripts/Story/StoryRepository.cs
@@ -1,29 +1,64 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using DataVersion;
+using MasterDataVersion;
 using Script;
 using UnityEngine;
 
 namespace Story
 {
+    [Serializable]
+    public class Story2
+    {
+        public int id;
+        public string title;
+        public string sentences;
+        public string created_at;
+        public string updated_at;
+    }
+
     public class StoryRepository
     {
         SqliteDatabase sqlDB = new SqliteDatabase("config.db");
+
         public Story[] GetAll()
         {
             var sql = "select * from story";
             var dataTable = sqlDB.ExecuteQuery(sql);
-            return dataTable.Rows.Select((r) => new Story((int)r["id"], (string)r["title"], JsonUtility.FromJson<Sentences>((string)r["sentences"]))).ToArray();
+            return dataTable.Rows.Select((r) => new Story((int) r["id"], (string) r["title"],
+                JsonUtility.FromJson<Sentences>((string) r["sentences"]))).ToArray();
         }
+
         public Sentence[] Get(int id)
         {
-            var sql = "select * from story where id="+id;
+            var sql = "select * from story where id=" + id;
             DataTable dataTable = sqlDB.ExecuteQuery(sql);
             foreach (var row in dataTable.Rows)
             {
-                var story = new Story((int) row["id"], (string)row["title"], JsonUtility.FromJson<Sentences>((string)row["sentences"]));
+                var story = new Story((int) row["id"], (string) row["title"],
+                    JsonUtility.FromJson<Sentences>((string) row["sentences"]));
                 return story.sentences.sentences;
             }
+
             return null;
+        }
+
+        public async void UpdateFromMasterData()
+        {
+            var localDataVersion = new LocalDataVersionRepository().GetLocalDataVersion();
+            var masterDataVersion = await new MasterDataVersionApi().GetMasterDataVersion();
+            var stories = await new StoryApi().GetAll();
+            foreach (var story in stories)
+            {
+                if (localDataVersion < masterDataVersion)
+                {
+                    Debug.Log(story.id);
+                    Debug.Log(story.title);
+                    var sql = $"insert into story Values({story.id}, '{story.title}', '{story.sentences}')";
+                    sqlDB.ExecuteNonQuery(sql);
+                }
+            }
         }
     }
 }

--- a/Assets/Scripts/Title/TitleController.cs
+++ b/Assets/Scripts/Title/TitleController.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 using UnityEngine.SceneManagement;
 using GachaController.Auth;
 using Dialog;
+using Story;
 
 namespace Title
 {
@@ -16,6 +17,8 @@ namespace Title
         // Start is called before the first frame update
         void Start()
         {
+            // new StoryRepository().Insert();
+            new StoryRepository().UpdateFromMasterData();
         }
 
         // Update is called once per frame


### PR DESCRIPTION
## why
- アップデートによるデータ更新を想定したマスタデータ取得ができる状態になっていなかった

## what
- 以下の条件で、マスタデータサーバー（localhost:8001を想定）からのストーリーデータ取得
  - playerPrefsに保存したint値がマスターデータサーバのバージョン値よりも小さい