### PR TITLE
マスターデータバージョンのスタブを本物に差し替え

### DIFF
--- a/Assets/Scripts/DataVersion/MasterDataVersionApi.cs
+++ b/Assets/Scripts/DataVersion/MasterDataVersionApi.cs
@@ -1,12 +1,22 @@
+using System;
 using Cysharp.Threading.Tasks;
+using UnityEngine;
+using UnityEngine.Networking;
 
 namespace DataVersion
 {
+    [Serializable]
+    public class StoryMasterDataVersion
+    {
+        public int version;
+    }
     public class MasterDataVersionApi
     {
-        public async UniTask<int> GetMasterDataVersion()
+        public async UniTask<int> GetStoryMasterDataVersion()
         {
-            return 2;
+            var request = UnityWebRequest.Get("http://localhost:8001/api/storyMasterDataVersion/");
+            await request.SendWebRequest();
+            return JsonUtility.FromJson<StoryMasterDataVersion>(request.downloadHandler.text).version;
         }
     }
 }

--- a/Assets/Scripts/Story/StoryRepository.cs
+++ b/Assets/Scripts/Story/StoryRepository.cs
@@ -47,7 +47,7 @@ namespace Story
         public async void UpdateFromMasterData()
         {
             var localDataVersion = new LocalDataVersionRepository().GetLocalDataVersion();
-            var masterDataVersion = await new MasterDataVersionApi().GetMasterDataVersion();
+            var masterDataVersion = await new MasterDataVersionApi().GetStoryMasterDataVersion();
             var stories = await new StoryApi().GetAll();
             foreach (var story in stories)
             {


### PR DESCRIPTION
ストーリーの取得の際にMasterDataVersionApiでスタブを使っていたが、本物に差し替え