### PR TITLE
ストーリーリストを読める・読めないで区別する

### DIFF
--- a/.idea/.idea.HokumaFriends/.idea/contentModel.xml
+++ b/.idea/.idea.HokumaFriends/.idea/contentModel.xml
@@ -52,8 +52,10 @@
               <e p="MessageProceedManager.cs" t="Include" />
               <e p="sentence.cs" t="Include" />
               <e p="Story.cs" t="Include" />
+              <e p="StoryProgress.cs" t="Include" />
             </e>
             <e p="StoryApi.cs" t="Include" />
+            <e p="StoryProgressRepository.cs" t="Include" />
             <e p="StoryRepository.cs" t="Include" />
             <e p="Views" t="Include">
               <e p="MessageArea.cs" t="Include" />

--- a/Assets/Scripts/Story/Models/StoryProgress.cs
+++ b/Assets/Scripts/Story/Models/StoryProgress.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace Story.Models
+{
+    [Serializable]
+    public class StoryProgress
+    {
+        public int latest_readable;
+    }
+}

--- a/Assets/Scripts/Story/Models/StoryProgress.cs.meta
+++ b/Assets/Scripts/Story/Models/StoryProgress.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 3ef6678e145a4bd08fdb31b44db5e61b
+timeCreated: 1611271952

--- a/Assets/Scripts/Story/StoryProgressRepository.cs
+++ b/Assets/Scripts/Story/StoryProgressRepository.cs
@@ -1,0 +1,23 @@
+using Common.Api;
+using Cysharp.Threading.Tasks;
+using GachaController.Auth;
+using Story.Models;
+using UnityEditorInternal.Profiling.Memory.Experimental;
+using UnityEngine;
+using UnityEngine.Networking;
+
+namespace Story
+{
+    public class StoryProgressRepository
+    {
+        public async UniTask<StoryProgress> Get()  
+        {
+            var request = UnityWebRequest.Get(ApiHostName.instance.hostName + "/api/auth/storyProgress");
+            request.SetRequestHeader("Authorization", "Bearer "+(new LoginService()).LoadAccessToken());
+            await request.SendWebRequest();
+            var storyProgress = JsonUtility.FromJson<StoryProgress>(request.downloadHandler.text);
+            Debug.Log(request.downloadHandler.text);
+            return storyProgress;
+        }
+    }
+}

--- a/Assets/Scripts/Story/StoryProgressRepository.cs.meta
+++ b/Assets/Scripts/Story/StoryProgressRepository.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 5729dbb5d61b4254b1c4f5efae4aefbe
+timeCreated: 1611271896

--- a/Assets/Scripts/Story/Views/StoryListController.cs
+++ b/Assets/Scripts/Story/Views/StoryListController.cs
@@ -45,9 +45,10 @@ namespace Story
             SceneManager.sceneLoaded -= StorySceneLoaded;
         }
 
-        void SetupStoryListView()
+        async void SetupStoryListView()
         {
             var storyList = new StoryRepository().GetAll();
+            var storyProgress = await new StoryProgressRepository().Get();
             int i = 0;
             foreach (var story in storyList)
             {
@@ -56,7 +57,15 @@ namespace Story
                 text.text = story.title;
                 storyListButtonObj.transform.localPosition = new Vector3(0, -50*i);
                 var button = storyListButtonObj.GetComponent<Button>();
-                button.onClick.AddListener(()=>LoadStoryScene(story.id));
+                Debug.Log(storyProgress.latest_readable);
+                if (story.id <= storyProgress.latest_readable)
+                {
+                    button.onClick.AddListener(()=>LoadStoryScene(story.id));
+                }
+                else
+                {
+                    button.interactable = false;
+                }
                 storyListButtonObj.transform.SetParent(canvas.transform, false);
                 i++;
             }


### PR DESCRIPTION
## why
全てのストーリーがすぐ読めてしまうので、順番にしか読めないようにしたい

## what
/api/auth/storyProgress からデータを取得し、ストーリーリストシーン内のボタンを読める・読めないに応じてenable/disable状態にする

<img width="807" alt="スクリーンショット 2021-01-22 8 56 51" src="https://user-images.githubusercontent.com/24940519/105427118-c7f91280-5c8f-11eb-9a32-0fc9401d0fcd.png">
